### PR TITLE
add page breaks before diagrams in reports

### DIFF
--- a/src/content/joint-custom.css
+++ b/src/content/joint-custom.css
@@ -81,11 +81,21 @@ text.hasOpenThreats  {
 
 /* responsive paper */
 
+.tmt-diagram-title {
+  page-break-before: always;
+}
+
 .tmt-diagram-container {
+  page-break-before: avoid;
+  page-break-inside: avoid;
   height: 100%;
   width: 100%;
   overflow-x: auto;
   overflow-y: auto;
+}
+
+.tmt-diagram-element {
+  page-break-inside: avoid;
 }
 
 /*stencil*/

--- a/src/content/threatdragon-core.css
+++ b/src/content/threatdragon-core.css
@@ -8935,11 +8935,21 @@ text.hasOpenThreats {
 
 /* responsive paper */
 
+.tmt-diagram-title {
+  page-break-before: always;
+}
+
 .tmt-diagram-container {
+  page-break-before: avoid;
+  page-break-inside: avoid;
   height: 100%;
   width: 100%;
   overflow-x: auto;
   overflow-y: auto;
+}
+
+.tmt-diagram-element {
+  page-break-inside: avoid;
 }
 
 /*stencil*/

--- a/src/templates.js
+++ b/src/templates.js
@@ -710,7 +710,7 @@ angular.module('templates', [])
     '    </div>\n' +
     '    <div ng-repeat="diagram in model.detail.diagrams">\n' +
     '        <div class="panel panel-default">\n' +
-    '            <div class="panel-heading panel-title">\n' +
+    '            <div class="panel-heading panel-title tmt-diagram-title">\n' +
     '                <h4>{{diagram.title}}</h4>\n' +
     '            </div>\n' +
     '            <div class="panel-body">\n' +
@@ -718,7 +718,7 @@ angular.module('templates', [])
     '                    <tmt-diagram graph="graphs[diagram.id]" initialise-graph="initialise(diagram)" height="487" width="650" grid-size="1" interactive="false"/>\n' +
     '                </div>\n' +
     '                <div ng-repeat="element in graphs[diagram.id].getCells() | filter:{outOfScope: \'!true\'}">\n' +
-    '                    <div ng-if="element.attributes.type != \'tm.Boundary\'" class="panel panel-default model-element">\n' +
+    '                    <div ng-if="element.attributes.type != \'tm.Boundary\'" class="panel panel-default model-element tmt-diagram-element">\n' +
     '                        <div class="panel-heading panel-title">\n' +
     '                            {{element.name}}\n' +
     '                            <span ng-switch="element.attributes.type">\n' +

--- a/src/threatmodels/threatmodelreport.html
+++ b/src/threatmodels/threatmodelreport.html
@@ -56,7 +56,7 @@
     </div>
     <div ng-repeat="diagram in model.detail.diagrams">
         <div class="panel panel-default">
-            <div class="panel-heading panel-title">
+            <div class="panel-heading panel-title tmt-diagram-title">
                 <h4>{{diagram.title}}</h4>
             </div>
             <div class="panel-body">
@@ -64,7 +64,7 @@
                     <tmt-diagram graph="graphs[diagram.id]" initialise-graph="initialise(diagram)" height="487" width="650" grid-size="1" interactive="false"/>
                 </div>
                 <div ng-repeat="element in graphs[diagram.id].getCells() | filter:{outOfScope: '!true'}">
-                    <div ng-if="element.attributes.type != 'tm.Boundary'" class="panel panel-default model-element">
+                    <div ng-if="element.attributes.type != 'tm.Boundary'" class="panel panel-default model-element tmt-diagram-element">
                         <div class="panel-heading panel-title">
                             {{element.name}}
                             <span ng-switch="element.attributes.type">


### PR DESCRIPTION
This adds a page break in the report before each diagram, and also ensures that diagrams are not interrupted by a page break 