### PR TITLE
Fix dirty flag not set after editing threat

### DIFF
--- a/src/diagrams/diagrameditor.html
+++ b/src/diagrams/diagrameditor.html
@@ -23,7 +23,7 @@
                     </div>
                     <div ng-if="vm.selected && vm.selected.attributes.type != 'tm.Boundary'">
                         <div ng-if="!vm.selected.outOfScope">
-                            <tmt-element-threats suggest="vm.generateThreats" threats="vm.selected.threats" type="vm.diagram.diagramType" save="vm.edit" />
+                            <tmt-element-threats suggest="vm.generateThreats" threats="vm.selected.threats" type="vm.diagram.diagramType" save="vm.edit" setdirty="vm.setDirty" />
                         </div>
                         <div ng-if="vm.selected.outOfScope">
                             <em>The selected element is out of scope</em>

--- a/src/diagrams/elementpropdirectives.js
+++ b/src/diagrams/elementpropdirectives.js
@@ -66,7 +66,8 @@ function elementThreats($routeParams, $location, common, dialogs) {
                 suggest: '=',
                 threats: '=',
                 type: '=',
-                save: '&'
+                save: '&',
+                setdirty: '=',
             }
         };
 
@@ -101,6 +102,7 @@ function elementThreats($routeParams, $location, common, dialogs) {
         scope.removeThreat = function (index) {
             scope.threats.splice(index, 1);
             scope.save();
+            scope.setdirty();
         };
 
         scope.addThreat = function () {
@@ -111,6 +113,7 @@ function elementThreats($routeParams, $location, common, dialogs) {
 
             scope.threats.push(newThreat);
             scope.save({ threat: newThreat });
+            scope.setdirty();
             reset(scope.type);
         };
 
@@ -120,6 +123,7 @@ function elementThreats($routeParams, $location, common, dialogs) {
 
         scope.editThreat = function () {
             scope.save();
+            scope.setdirty();
             reset(scope.type);
         };
 

--- a/src/templates.js
+++ b/src/templates.js
@@ -122,7 +122,7 @@ angular.module('templates', [])
     '                    </div>\n' +
     '                    <div ng-if="vm.selected && vm.selected.attributes.type != \'tm.Boundary\'">\n' +
     '                        <div ng-if="!vm.selected.outOfScope">\n' +
-    '                            <tmt-element-threats suggest="vm.generateThreats" threats="vm.selected.threats" type="vm.diagram.diagramType" save="vm.edit" />\n' +
+    '                            <tmt-element-threats suggest="vm.generateThreats" threats="vm.selected.threats" type="vm.diagram.diagramType" save="vm.edit" setdirty="vm.setDirty" />\n' +
     '                        </div>\n' +
     '                        <div ng-if="vm.selected.outOfScope">\n' +
     '                            <em>The selected element is out of scope</em>\n' +

--- a/test/spec/elementpropertydirectives_spec.js
+++ b/test/spec/elementpropertydirectives_spec.js
@@ -532,13 +532,13 @@ describe('element threats directive: ', function () {
             var onCancel = mockDialogs.confirm.calls.argsFor(0)[3];
             onCancel();
             expect($scope.edit).not.toHaveBeenCalled();
+            expect($scope.setDirty).not.toHaveBeenCalled();
             expect($location.search().threat).toBeUndefined();
 
         });
 
         it('should remove a threat', function () {
 
-            $scope.dirty = false;
             angular.element($('#remove1')).triggerHandler('click');
             expect($scope.edit).toHaveBeenCalled();
             expect($scope.setDirty).toHaveBeenCalled();

--- a/test/spec/elementpropertydirectives_spec.js
+++ b/test/spec/elementpropertydirectives_spec.js
@@ -431,11 +431,14 @@ describe('element threats directive: ', function () {
         spyOn($scope, 'edit');
         $scope.threats = [threat0, threat1, threat2];
 
+        $scope.setDirty = function() {}
+        spyOn($scope, 'setDirty');
+
         //dialogs mocks
         mockDialogs.confirm = function () { };
         spyOn(mockDialogs, 'confirm');
 
-        elem = angular.element('<tmt-element-threats threats="threats" save="edit()" />');
+        elem = angular.element('<tmt-element-threats threats="threats" save="edit()" setdirty="setDirty" />');
 
     });
 
@@ -495,6 +498,7 @@ describe('element threats directive: ', function () {
             onOK();
             expect($scope.threats.length).toEqual(originalLength + 1);
             expect($scope.edit).toHaveBeenCalled();
+            expect($scope.setDirty).toHaveBeenCalled();
             expect(param().editing).toBe(true);
 
         });
@@ -517,6 +521,7 @@ describe('element threats directive: ', function () {
             expect(param().threat).toEqual(threat1);
             expect(param().editing).toBe(true);
             expect($scope.edit).toHaveBeenCalled();
+            expect($scope.setDirty).toHaveBeenCalled();
             expect($location.search().threat).toBeUndefined();
 
         });
@@ -533,8 +538,10 @@ describe('element threats directive: ', function () {
 
         it('should remove a threat', function () {
 
+            $scope.dirty = false;
             angular.element($('#remove1')).triggerHandler('click');
             expect($scope.edit).toHaveBeenCalled();
+            expect($scope.setDirty).toHaveBeenCalled();
             expect($scope.threats).toEqual([threat0, threat2]);
 
         });


### PR DESCRIPTION
<!--
Please provide enough information so that others can review your pull request.
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.
The first three fields are mandatory:
-->
**- Summary**


<!--
Explain the motivation for making this change.
What existing issue does the pull request solve?
-->
Fixes issue #49 where a diagram was not set to dirty after modifying or deleting an existing threat.
**- Tests**

<!--
Demonstrate the code is solid.
Ensure the the code passes the `npm run-script pretest` and the `npm test` stages.
-->
All tests pass and I inserted an additional check to verify that the action of adding, removing or editing a threat invoke the setdirty function.
**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Unsaved changes made to threats in a diagram are now notified before exiting.

<!--
Thanks for submitting a pull request!
Please make sure you've read and understood our contributing guidelines;
https://github.com/OWASP/threat-dragon/blob/main/CONTRIBUTING.md
-->
